### PR TITLE
chore upgrade lambda node version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "generate_value" {
   source_code_hash = data.archive_file.generate_value.output_base64sha256
   timeout          = 30
   handler          = "index.handler"
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs22.x"
   environment {
     variables = {
       PARAMETER_NAME : (var.use_secrets_manager ? aws_secretsmanager_secret.secret[0].id : var.parameter_name),


### PR DESCRIPTION
Upgrade Node.js version from 18 to 22 since it has reached EOL for support from AWS.